### PR TITLE
Update to avoid component errors

### DIFF
--- a/components/Menu.php
+++ b/components/Menu.php
@@ -114,10 +114,13 @@ class Menu extends ComponentBase
             $baseFileName = $this->page->page->getBaseFileName();
 
             // And make sure the active page is a child of the parentNode
-            $activeNode = menuModel::where('url', $baseFileName)
-                ->where('nest_left', '>', $topNode->nest_left)
-                ->where('nest_right', '<', $topNode->nest_right)
-                ->first();
+            if ($topNode) {
+                $activeNode = menuModel::where('url', $baseFileName)
+                    ->where('nest_left', '>', $topNode->nest_left)
+                    ->where('nest_right', '<', $topNode->nest_right)
+                    ->first();
+            }
+            
         }
 
         // If I've got a result that is a


### PR DESCRIPTION
Update to avoid component errors if no menu items are in menu, for example, if plugin has been re-installed, or menu has been deleted, then the top level menu item needs re-selecting in the component `Parent Node` field. This will however be blank after re-install or if menu has been deleted, and will throw the Exception error:
![exception](https://cloud.githubusercontent.com/assets/7501909/3286235/aecc2a9e-f545-11e3-8451-afe001bc946f.png)
