### PR TITLE
Use NestedTree trait in favour of NestedSet behavior

### DIFF
--- a/models/Menu.php
+++ b/models/Menu.php
@@ -12,7 +12,6 @@ use System\Classes\ApplicationException;
 class Menu extends Model
 {
 
-    // @todo find out why this is now inside the class
     use \October\Rain\Database\Traits\NestedTree;
 
     /**
@@ -36,11 +35,6 @@ class Menu extends Model
     public $rules = [
         'title' => 'required'
     ];
-
-    /**
-     * @var array
-     */
-    public $implement = ['October.Rain.Database.Behaviors.NestedSetModel'];
 
     /**
      * Returns the list of menu items, where the key is the id and the value is the title, indented with '-' for depth


### PR DESCRIPTION
You should be using NestedTree trait (recommended) or NestedSetModel behavior, but not both :-)

NestedSetModel behavior is deprecated:

```
/**
 *
 * DEPRECATED WARNING: This class is deprecated and should be deleted
 * if the current year is equal to or greater than 2015.
 * 
 * @todo Delete this file if year >= 2015.
 *
 * See trait: October\Rain\Database\Traits\NestedTree
 *
 */
```

This could fix issue #10
