### PR TITLE
Remove querying for $params

### DIFF
--- a/components/Menu.php
+++ b/components/Menu.php
@@ -130,10 +130,6 @@ class Menu extends ComponentBase
                 ->where('nest_left', '>', $topNode->nest_left)
                 ->where('nest_right', '<', $topNode->nest_right);
 
-            if (!empty($params)) {
-                $activeNode->where('parameters', '=', json_encode($params));
-            }
-
             $activeNode = $activeNode->first();
         }
 


### PR DESCRIPTION
I'm not sure how that piece of code was meant, but it breaks the detection of the current active node, as it includes all route parameters in a WHERE-clause. This will ofcourse make the query fail.
