### PR TITLE
Fixed an issue that #8bccc823 introduced

### DIFF
--- a/models/Menu.php
+++ b/models/Menu.php
@@ -142,6 +142,16 @@ class Menu extends Model
     }
 
     /**
+     * Returns the class name so I can compare
+     *
+     * @return string
+     */
+    public static function getClassName()
+    {
+        return get_called_class();
+     }
+
+    /**
      * Returns the correct url for this menu item.
      * It will either be the full page URL or '#' if no link was provided
      *


### PR DESCRIPTION
This method is required, or else You get this error:

```
exception 'BadMethodCallException' with message 'Call to undefined method October\Rain\Database\QueryBuilder::getClassName()' in /home3/apelsin5/public_html/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1992
```