### PR TITLE
 The reserved indicator "@" cannot start a plain scalar

### DIFF
--- a/controllers/Menus.php
+++ b/controllers/Menus.php
@@ -67,7 +67,7 @@ class Menus extends Controller
         $this->pageTitle = Lang::get('benfreke.menumanager::lang.menu.reordermenu');
 
         $toolbarConfig = $this->makeConfig();
-        $toolbarConfig->buttons = '@/plugins/benfreke/menumanager/controllers/menus/_reorder_toolbar.htm';
+        $toolbarConfig->buttons = $/benfreke/menumanager/controllers/menus/_reorder_toolbar.htm';
 
         $this->vars['toolbar'] = $this->makeWidget('Backend\Widgets\Toolbar', $toolbarConfig);
         $this->vars['records'] = Menu::make()->getEagerRoot();


### PR DESCRIPTION
production.ERROR: Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 9 (near "form: @/plugins/benfreke/menumanager/models/menu/fields.yaml")