### PR TITLE
Fix path to partial

### DIFF
--- a/controllers/Menus.php
+++ b/controllers/Menus.php
@@ -67,7 +67,7 @@ class Menus extends Controller
         $this->pageTitle = Lang::get('benfreke.menumanager::lang.menu.reordermenu');
 
         $toolbarConfig = $this->makeConfig();
-        $toolbarConfig->buttons = '~/benfreke/menumanager/controllers/menus/_reorder_toolbar.htm';
+        $toolbarConfig->buttons = '$/benfreke/menumanager/controllers/menus/_reorder_toolbar.htm';
 
         $this->vars['toolbar'] = $this->makeWidget('Backend\Widgets\Toolbar', $toolbarConfig);
         $this->vars['records'] = Menu::make()->getEagerRoot();


### PR DESCRIPTION
I see the latest fix added the ~, but that one actually references the base direcctory, not the /plugins directory. Correct is $.