### PR TITLE
+ Add option to select and delete multiple items in the menu listing view

### DIFF
--- a/controllers/menus/_list_toolbar.htm
+++ b/controllers/menus/_list_toolbar.htm
@@ -1,4 +1,24 @@
 <div data-control="toolbar">
+    <!-- Create a new item -->
     <a href="<?= Backend::url('benfreke/menumanager/menus/create') ?>" class="btn btn-primary oc-icon-plus"><?= e(trans('benfreke.menumanager::lang.misc.newmenu')); ?></a>
+
+    <!-- Delete selected item(s) -->
+    <button
+        class="btn btn-default oc-icon-trash-o"
+        disabled="disabled"
+        onclick="$(this).data('request-data', {
+            checked: $('.control-list').listWidget('getChecked')
+        })"
+        data-request="onDelete"
+        data-request-confirm="<?= e(trans('backend::lang.list.delete_selected_confirm')) ?>"
+        data-trigger-action="enable"
+        data-trigger=".control-list input[type=checkbox]"
+        data-trigger-condition="checked"
+        data-request-success="$(this).prop('disabled', true)"
+        data-stripe-load-indicator>
+        <?= e(trans('backend::lang.list.delete_selected')) ?>
+    </button>
+
+    <!-- Reorder items -->
     <a href="<?= Backend::url('benfreke/menumanager/menus/reorder') ?>" class="btn btn-default oc-icon-bars"><?= e(trans('benfreke.menumanager::lang.misc.manageorder')); ?></a>
 </div>

--- a/controllers/menus/config_list.yaml
+++ b/controllers/menus/config_list.yaml
@@ -22,6 +22,9 @@ recordsPerPage: 50
 
 showTree: true
 
+# Show selectable checkboxes next to each menu item in the main list
+showCheckboxes: true
+
 # Toolbar widget configuration
 toolbar:
     # Partial for toolbar buttons


### PR DESCRIPTION
This PR adds a new button in the menu listing page that allows the user to select and delete multiple menu items if so desired. The natural behaviour of the NestedTree in OctoberCMS is to delete the selected item and all of its children so that is what happens when a root item is deleted.

This fix is related to the following issue in the main repository:
https://github.com/benfreke/oc-menumanager-plugin/issues/83

<img width="861" alt="screen shot 2018-05-21 at 9 32 00 am" src="https://user-images.githubusercontent.com/960438/40310402-9b6004ac-5cda-11e8-9ccf-64521faa50f0.png">

<img width="1105" alt="screen shot 2018-05-21 at 9 32 23 am" src="https://user-images.githubusercontent.com/960438/40310406-a061d3a4-5cda-11e8-8bcb-dcd9f10df346.png">

