### PR TITLE
Add parameters as translatable field

### DIFF
--- a/models/Menu.php
+++ b/models/Menu.php
@@ -26,7 +26,7 @@ class Menu extends Model
     /**
      * @var array Translatable fields
      */
-    public $translatable = ['title', 'description'];
+    public $translatable = ['title', 'description', 'parameters'];
 
     /**
      * @var array Validation rules


### PR DESCRIPTION
This will add `parameters` as a translatable field. When using multilanguage on a website, the parameters can also be translated. This wasn't possible in prior versions.

Example in old situation:

    English Link: https://example.com/products/car
    Dutch Link: https://example.com/producten/car

By making `parameters` translatable we can use the parameters as this:

    English Link: https://example.com/products/car
    Dutch Link: https://example.com/producten/auto